### PR TITLE
Streamline schema upload with automatic versioning

### DIFF
--- a/linkml-schema-manager/app/services/schema_service.py
+++ b/linkml-schema-manager/app/services/schema_service.py
@@ -19,6 +19,48 @@ class SchemaService:
     """Service for managing LinkML schemas."""
 
     @staticmethod
+    def generate_next_version(existing_versions: List[SchemaVersion]) -> str:
+        """
+        Generate the next version number based on existing versions.
+        Uses semantic versioning (MAJOR.MINOR.PATCH).
+
+        If no versions exist, returns "1.0.0".
+        Otherwise, increments the MINOR version.
+        """
+        if not existing_versions:
+            return "1.0.0"
+
+        # Try to parse semantic versions
+        max_version = (1, 0, 0)  # Default
+
+        for version in existing_versions:
+            try:
+                # Try to parse as semantic version (e.g., "1.2.3")
+                parts = version.version.split('.')
+                if len(parts) >= 3:
+                    major = int(parts[0])
+                    minor = int(parts[1])
+                    patch = int(parts[2])
+                    current = (major, minor, patch)
+
+                    if current > max_version:
+                        max_version = current
+                elif len(parts) == 2:
+                    major = int(parts[0])
+                    minor = int(parts[1])
+                    current = (major, minor, 0)
+
+                    if current > max_version:
+                        max_version = current
+            except (ValueError, AttributeError):
+                # If version doesn't follow semantic versioning, skip it
+                continue
+
+        # Increment minor version
+        major, minor, patch = max_version
+        return f"{major}.{minor + 1}.0"
+
+    @staticmethod
     async def create_schema(
         db: AsyncSession,
         name: str,


### PR DESCRIPTION
Simplified the schema upload workflow to be more intuitive:
- Single POST /schemas/ endpoint now handles both new schemas and versions
- Automatically creates schema if name is new
- Automatically creates new version if schema name exists
- Auto-generates semantic version numbers (1.0.0 → 1.1.0 → 1.2.0)
- Version can be manually specified if desired

Changes:

API Router (app/routers/schemas.py):
- Refactored POST /schemas/ endpoint to accept file upload
- Renamed endpoint from create_schema to upload_schema
- Added automatic schema creation or version creation logic
- Version auto-generation with SchemaService.generate_next_version()
- Kept POST /schemas/{schema_name}/versions as alternative method

Schema Service (app/services/schema_service.py):
- Added generate_next_version() method
- Implements semantic versioning auto-increment
- Parses existing versions and increments MINOR version
- Falls back gracefully for non-semantic version strings

Documentation (README.md):
- Updated features to highlight smart upload and auto-versioning
- Revised API endpoint documentation
- Updated example workflow to show simplified process
- Single upload creates schema + first version
- Re-uploading same name creates new version automatically

Benefits:
- More intuitive user experience
- Fewer steps to upload schemas
- Automatic version management
- Backward compatible (explicit version endpoint still available)